### PR TITLE
fix(Table): Let `TableItem` support nest prop in data.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "lodash.get": "^4.4.2",
     "manba": "^1.2.0"
   },
   "devDependencies": {

--- a/src/components/table/table-td.vue
+++ b/src/components/table/table-td.vue
@@ -3,6 +3,7 @@
 </template>
 <script>
 import utils from '../../utils/utils';
+import _get from 'lodash.get';
 
 export default {
   name: 'hTableTd',
@@ -25,7 +26,7 @@ export default {
     },
     show() {
       if (this.prop=='$index') return this.index;
-      let value = this.data[this.prop];
+      let value = _get(this.data, this.prop);
       if (this.dict) {
         return utils.dictMapping(value, this.dict);
       }


### PR DESCRIPTION
例子：
```vue
<template>
  <div>
    <p> <Button color="blue" icon="h-icon-plus" @click="add(datas)">添加一行</Button></p>
    <Table :datas="datas" stripe checkbox>
      <TableItem title="Index" :tooltip="true"><template slot-scope="{index}">{{index}}</template></TableItem>
      <TableItem title="Name" prop="name" sort="auto"></TableItem>
      <TableItem title="Age" prop="age"></TableItem>
      <TableItem title="Address" align="center" prop="address.city"></TableItem>
    </Table>
  </div>
</template>

<script>
export default {
  data() {
    return {
      datas: [
        { id: 5, name: '测试5', age: 12, address: { city:"上海" } },
    }
  },
...
}
</script>
```