### PR TITLE
feat(Table): add sortInit prop

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -12,7 +12,7 @@
               <CheckboxAll v-if="fixedColumnLeft.length==0" :checks="checks" :checkableDatas="checkableDatas" @checkAll="checkAll"></CheckboxAll>
             </th>
             <th v-if="radio&&thindex==0" class="h-table-th-radio" :rowspan="ths.length"></th>
-            <TableTh v-for="(thdata, index) of thdata" :key="index+update.columns" v-bind="thdata" :sortStatus="sortStatus"></TableTh>
+            <TableTh v-for="(thdata, index) of thdata" :key="index+update.columns" v-bind="thdata" :sortStatus="sortStatus" :sortInit="sortInit"></TableTh>
           </tr>
         </template>
         <tr v-else>
@@ -20,7 +20,7 @@
             <CheckboxAll v-if="fixedColumnLeft.length==0" :checks="checks" :checkableDatas="checkableDatas" @checkAll="checkAll"></CheckboxAll>
           </th>
           <th v-else-if="radio" class="h-table-th-radio"></th>
-          <TableTh v-for="(c, index) of computeColumns" :key="index+update.columns" v-bind="c" :sortStatus="sortStatus"></TableTh>
+          <TableTh v-for="(c, index) of computeColumns" :key="index+update.columns" v-bind="c" :sortStatus="sortStatus" :sortInit="sortInit"></TableTh>
         </tr>
       </table>
       <div class="h-table-fixed-cover" :style="{'width': (scrollWidth+'px')}"></div>
@@ -116,7 +116,7 @@
             <CheckboxAll :checks="checks" :checkableDatas="checkableDatas" @checkAll="checkAll"></CheckboxAll>
           </th>
           <th v-if="radio" class="h-table-th-radio"> </th>
-          <TableTh v-for="(thdata, index) of fixedColumnLeft" :key="index+update.columns" v-bind="thdata" :sortStatus="sortStatus"></TableTh>
+          <TableTh v-for="(thdata, index) of fixedColumnLeft" :key="index+update.columns" v-bind="thdata" :sortStatus="sortStatus" :sortInit="sortInit"></TableTh>
         </tr>
       </table>
     </div>
@@ -126,7 +126,7 @@
           <col v-for="(c, index) of fixedColumnRight" :width="getWidth(c)" :key="index+update.columns" />
         </colgroup>
         <tr>
-          <TableTh v-for="(thdata, index) of fixedColumnRight" :key="index+update.columns" v-bind="thdata" :sortStatus="sortStatus"></TableTh>
+          <TableTh v-for="(thdata, index) of fixedColumnRight" :key="index+update.columns" v-bind="thdata" :sortStatus="sortStatus" :sortInit="sortInit"></TableTh>
         </tr>
       </table>
     </div>
@@ -195,7 +195,11 @@ export default {
       type: Boolean,
       default: false
     },
-    getTrClass: Function
+    getTrClass: Function,
+    sortInit: {
+      type: String,
+      default: ''
+    }
   },
   data() {
     return {

--- a/src/components/table/tableth.vue
+++ b/src/components/table/tableth.vue
@@ -33,6 +33,7 @@ export default {
       default: false
     },
     sortProp: String,
+    sortInit: String,
     sort: {
       type: [Boolean, String],
       default: false
@@ -56,7 +57,11 @@ export default {
       if (this.sortStatus.type && this.sortStatus.prop == this.sortUseProp) {
         sortStatus.type = this.sortStatus.type == 'asc' ? 'desc' : 'asc';
       } else {
-        sortStatus.type = 'desc';
+        if (this.sortInit && (this.sortInit == 'asc' || this.sortInit == 'desc')) {
+          sortStatus.type = this.sortInit;
+        } else {
+          sortStatus.type = 'desc';
+        }
         sortStatus.prop = this.sortUseProp;
       }
       let parent = this.$parent;


### PR DESCRIPTION
I added a new prop, so we can start sorting by asc or desc, for example in table:

`<Table v-bind="{ sortInit: 'asc' }" @sort="triggerSort" :datas="datas"></Table>`